### PR TITLE
prevent token loss on withdraw request

### DIFF
--- a/contracts/Chorus.sol
+++ b/contracts/Chorus.sol
@@ -150,6 +150,10 @@ contract Chorus is Inflation, OracleGetter, ERC20 {
         );
     }
 
+    function getWithdrawAmount(address _user) external view returns (uint256) {
+        return withdrawRequested[_user].amount;
+    }
+
     /**
      * @dev Function to allow anyone to liquidate the system if it is undercollateralized
      */
@@ -203,7 +207,7 @@ contract Chorus is Inflation, OracleGetter, ERC20 {
         require(_amount > 0, "amount should be greater than 0");
         require(balanceOf(msg.sender) >= _amount, "not enough balance");
         withdrawRequested[msg.sender].requestDate = block.timestamp;
-        withdrawRequested[msg.sender].amount = _amount;
+        withdrawRequested[msg.sender].amount += _amount;
         _transfer(msg.sender, address(this), _amount);
         emit WithdrawTokenRequest(msg.sender, _amount);
     }

--- a/contracts/Chorus.sol
+++ b/contracts/Chorus.sol
@@ -150,10 +150,6 @@ contract Chorus is Inflation, OracleGetter, ERC20 {
         );
     }
 
-    function getWithdrawAmount(address _user) external view returns (uint256) {
-        return withdrawRequested[_user].amount;
-    }
-
     /**
      * @dev Function to allow anyone to liquidate the system if it is undercollateralized
      */

--- a/test/chorusUnitTests.js
+++ b/test/chorusUnitTests.js
@@ -132,7 +132,7 @@ describe("Chorus Unit Tests", function () {
     //onlyAdmin: users shouldn't be able to deposit collateral
     await collateralTkn.mint(acc1.address, 10n*precision)
     let accColatteralBalance = await collateralTkn.balanceOf(acc1.address)
-    expect(chorus.connect(acc1).depositCollateral(accColatteralBalance),
+    await expect(chorus.connect(acc1).depositCollateral(accColatteralBalance),
       "non-admin deposited collateral").to.be.reverted
     //require 1: owner must deposit non-zero amount of collateral 
     expect(chorus.connect(owner).depositCollateral(0),


### PR DESCRIPTION
Increments the sender's requested amount instead of overwriting it. This preserves the user's original balance (no funds lost) and protects the withdrawal wait period.