### PR TITLE
Owner can't force liquidation

### DIFF
--- a/contracts/Chorus.sol
+++ b/contracts/Chorus.sol
@@ -229,7 +229,7 @@ contract Chorus is Inflation, OracleGetter, ERC20 {
 
     /**
      * @dev Allows the admin to set the Collateral threshold
-     * @param _amount new collateral threshold
+     * @param _amount new collateral threshold. 1e18 is 100%
      */
     function setCollateralThreshold(uint256 _amount)
         external

--- a/contracts/Chorus.sol
+++ b/contracts/Chorus.sol
@@ -237,8 +237,8 @@ contract Chorus is Inflation, OracleGetter, ERC20 {
         within100e18Range(_amount) //between 0% and 10,000%
     {
         require(
-            _amount > collateralRatio(),
-            "forced liquidation not allowed"
+            _amount > 1e18, // > 100%
+            "can only set collateral threshold above 100%"
         );
         collateralThreshold = _amount;
         emit CollateralThreshold(_amount);

--- a/contracts/Chorus.sol
+++ b/contracts/Chorus.sol
@@ -236,6 +236,10 @@ contract Chorus is Inflation, OracleGetter, ERC20 {
         onlyAdmin
         within100e18Range(_amount) //between 0% and 10,000%
     {
+        require(
+            _amount > collateralRatio(),
+            "forced liquidation not allowed"
+        );
         collateralThreshold = _amount;
         emit CollateralThreshold(_amount);
     }

--- a/test/chorusUnitTests.js
+++ b/test/chorusUnitTests.js
@@ -279,7 +279,7 @@ describe("Chorus Unit Tests", function () {
     //modifier: liqudation penalty can't be greater than 100%
     expect(
       chorus.connect(owner).setLiquidationPenalty(101e18),
-      "admisn was able to set liquidation penalty greater than 100%"
+      "admin was able to set liquidation penalty greater than 100%"
     ).to.be.reverted
 
   })

--- a/test/chorusUnitTests.js
+++ b/test/chorusUnitTests.js
@@ -269,8 +269,8 @@ describe("Chorus Unit Tests", function () {
     ).to.be.reverted
 
     await expect(
-      chorus.connect(owner).setCollateralThreshold(BigInt(1)), //arbitrarily low collat threshold
-      "owner forced liquidation"
+      chorus.connect(owner).setCollateralThreshold(BigInt(99) / BigInt(100) * precision), //99%
+      "owner set collateral threshold below 100%"
     ).to.be.reverted
   })
 

--- a/test/chorusUnitTests.js
+++ b/test/chorusUnitTests.js
@@ -259,12 +259,19 @@ describe("Chorus Unit Tests", function () {
 
   it("set collateral threshold", async function () {
 
+    await chorus.connect(owner).depositCollateral(20n*precision)
+    await chorus.connect(owner).mintToken(10n*precision, acc1.address)
+
     //modifier: collateral ratio should be between 0% and 10,000%
-    expect(
+    await expect(
       chorus.connect(owner).setCollateralThreshold(101e18),
       "admin was able to set collateral threshold above limit of 10,000%"
     ).to.be.reverted
 
+    await expect(
+      chorus.connect(owner).setCollateralThreshold(BigInt(1)), //arbitrarily low collat threshold
+      "owner forced liquidation"
+    ).to.be.reverted
   })
 
   it("set liquidation penalty", async function () {

--- a/test/endToEnd.js
+++ b/test/endToEnd.js
@@ -199,7 +199,7 @@ describe("Chorus e2e tests", function () {
   });
 
   it("Withdraw collateral", async function () {
-    let collateralDeposit = 10n;
+    let collateralDeposit = 11n;
     let ownerCollateralBalance = await collateralTkn.balanceOf(owner.address)
     await chorus.depositCollateral(collateralDeposit * precision)
     expect(Number(await collateralTkn.balanceOf(owner.address))).to.equal(Number(ownerCollateralBalance) - Number(collateralDeposit*precision));
@@ -208,9 +208,9 @@ describe("Chorus e2e tests", function () {
     await chorus.mintToken(tokensMinted * precision, acc1.address)
     let expWithdrawAmnt = 1n * precision;
     await chorus.withdrawCollateral(expWithdrawAmnt)
-    expect(Number(await collateralTkn.balanceOf(owner.address))).to.equal(Number(expWithdrawAmnt + 90n*precision));
-    expect(chorus.withdrawCollateral(1n * precision), "collateral withdraw puts the system below the threshold").to.be.reverted
-    expect(Number(await collateralTkn.balanceOf(owner.address))).to.equal(Number(expWithdrawAmnt + 90n*precision));
+    expect(Number(await collateralTkn.balanceOf(owner.address))).to.equal(Number(expWithdrawAmnt + 89n*precision));
+    await expect(chorus.withdrawCollateral(2n * precision), "collateral withdraw puts the system below the threshold").to.be.reverted
+    expect(Number(await collateralTkn.balanceOf(owner.address))).to.equal(Number(expWithdrawAmnt + 89n*precision));
   })
 
   it("Liquidation", async function () {


### PR DESCRIPTION
If owner wants to change the collateral threshold, the new ratio is required to be above the current collateral ratio. This prevents owners from forcing liquidation.